### PR TITLE
Fix rest function

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "pulp build && pulp test -- -w hello -w world"
   },
   "dependencies": {
-    "yargs": "^3.32.0"
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
     "pulp": "^11.0.0",

--- a/src/Node/Yargs/Applicative.purs
+++ b/src/Node/Yargs/Applicative.purs
@@ -142,5 +142,5 @@ flag key aliases desc = yarg key aliases desc (Left false) false
 -- | Get the raw command line arguments object.
 rest :: Y (Array Foreign)
 rest = Y { setup: mempty
-         , read: readArray
+         , read: readProp "_" >=> readArray
          }


### PR DESCRIPTION
`rest` is failing because it tries to read the array, but the input is an object that has `_` key for the remainder of the arguments:

```
> require('yargs')(['a', 'b', 'c']).argv
{ _: [ 'a', 'b', 'c' ], '$0': '' }
```

Also upgraded yargs dependency to the latest version.